### PR TITLE
Return an error when canonicalization fails

### DIFF
--- a/canonical.go
+++ b/canonical.go
@@ -19,7 +19,10 @@ func canonicalize(data interface{}) ([]byte, string, error) {
 	var buffer, out bytes.Buffer
 	writer := bufio.NewWriter(&buffer)
 	encoder := xml.NewEncoder(writer)
-	encoder.Encode(data)
+	err := encoder.Encode(data)
+	if err != nil {
+		return nil, "", err
+	}
 	encoder.Flush()
 	// read it back in
 	decoder := xml.NewDecoder(bytes.NewReader(buffer.Bytes()))


### PR DESCRIPTION
I noticed this error while trying to get it to work with iDeal (the Dutch customer payment system).